### PR TITLE
Enhance recovery mode logic in ClusterReconciler to ensure it only ex…

### DIFF
--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -234,13 +234,19 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 					return &ctrl.Result{Requeue: true}, err
 				}
 			} else if existing.Spec.PodManagementPolicy == appsv1.ParallelPodManagement {
-				// We are in Parallel mode but appear to not have a failure situation any longer. Switch back to normal mode
-				r.logger.Info(fmt.Sprintf("Ending recovery mode for nodepool %s", nodePool.Component))
-				if err := helpers.WaitForSTSDelete(r.client, &existing); err != nil {
-					r.logger.Error(err, "Failed to delete STS")
-					return result, err
+				// Only exit recovery mode if the cluster is actually healthy
+				if existing.Status.ReadyReplicas >= nodePool.Replicas-1 && 
+					existing.Status.ReadyReplicas > 0 {
+					r.logger.Info(fmt.Sprintf("Ending recovery mode for nodepool %s", nodePool.Component))
+					if err := helpers.WaitForSTSDelete(r.client, &existing); err != nil {
+						r.logger.Error(err, "Failed to delete STS")
+						return result, err
+					}
+					// STS will be recreated by the normal code below
+				} else {
+					// Still in recovery, just requeue with delay
+					return &ctrl.Result{RequeueAfter: time.Minute * 1}, nil
 				}
-				// STS will be recreated by the normal code below
 			}
 		}
 	}

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -244,8 +244,8 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 					}
 					// STS will be recreated by the normal code below
 				} else {
-					// Still in recovery, just requeue with delay
-					return &ctrl.Result{RequeueAfter: time.Minute * 1}, nil
+					// Still in recovery, just requeue
+					return &ctrl.Result{Requeue: true}, err
 				}
 			}
 		}


### PR DESCRIPTION
…its when the cluster is healthy, improving stability during node pool management.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
